### PR TITLE
Fix regression in ROS 2 Rolling (#155)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ endif ()
 
 find_package(ament_cmake QUIET)
 find_package(catkin QUIET)
+find_package(gtest_vendor)
+find_package(ament_cmake_ros)
 
 if(catkin_FOUND)
   ## ROS 1 -----------------------------------------------------------------------------------------------  

--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,8 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>ament_cmake_ros</depend>
+  <depend>gtest_vendor</depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>


### PR DESCRIPTION
Explicitly add ament_cmake_gtest to fix ROS 2 Rolling buildfarm error. Fixes #155.